### PR TITLE
Upgrading to 0.7.0 Beta

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN set -x && \
     gosu nobody true && \
     apk del .gosu-deps
 
-ENV NOMAD_VERSION 0.6.3
-ENV NOMAD_SHA256 908ee049bda380dc931be2c8dc905e41b58e59f68715dce896d69417381b1f4e
+ENV NOMAD_VERSION 0.7.0-beta1
+ENV NOMAD_SHA256 174794d96d2617252875e2e2ff9e496120acc4a97be54965c324b9a5d11b37ab
 
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip /tmp/nomad.zip
 RUN echo "${NOMAD_SHA256}  /tmp/nomad.zip" > /tmp/nomad.sha256 \


### PR DESCRIPTION
Nomad 0.7.0 Beta was released with ACL support. Not sure if I would tag it as latest but it probably would be a good idea to have a build.