### PR TITLE
Allow to override default environment variables values

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,25 @@ djenriquez/nomad:v0.6.0 agent
 ```
 
 The above command is identical to running this example in Nomad's documentation for [bootstrapping with Consul](https://www.nomadproject.io/docs/cluster/bootstrapping.html).
+
+# Correctly configuring Nomad data directory
+
+Due to the way Nomad exposed template files it generates, you need to take
+special precautions when configuring its data directory.
+
+In case you are running Docker containers and using the ``template`` stanza,
+the Nomad ``data_dir`` has to be configured with the **exact same path as the
+host path**, so the host Docker daemon mounts the correct paths, as exported by
+the Nomad client, into the scheduled Docker containers.
+
+You can run the Nomad container with the following options in this case:
+
+```bash
+export NOMAD_DATA_DIR=/host/path/to/nomad/data
+
+docker run \
+...\
+-v $NOMAD_DATA_DIR:$NOMAD_DATA_DIR:rw \
+-e NOMAD_DATA_DIR=$NOMAD_DATA_DIR \
+djenriquez/nomad:latest agent
+```

--- a/start.sh
+++ b/start.sh
@@ -13,8 +13,8 @@ set -e
 # NOMAD_CONFIG_DIR isn't exposed as a volume but you can compose additional
 # config files in there if you use this image as a base, or use NOMAD_LOCAL_CONFIG
 # below.
-NOMAD_DATA_DIR=/nomad/data
-NOMAD_CONFIG_DIR=/etc/nomad
+NOMAD_DATA_DIR=${NOMAD_DATA_DIR:-"/nomad/data"}
+NOMAD_CONFIG_DIR=${NOMAD_CONFIG_DIR:-"/etc/nomad"}
 
 # You can also set the NOMAD_LOCAL_CONFIG environemnt variable to pass some
 # Nomad configuration JSON without having to bind any volumes.


### PR DESCRIPTION
Defaults are the same as before, but they can now be overridden if
needed.
The README has been reflected to explain the use case.