### PR TITLE
Rev 0.8.6 (#18)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,14 @@ RUN set -x && \
     curl -L -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" && \
     curl -L -o /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" && \
     export GNUPGHOME="$(mktemp -d)" && \
-    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
+    for keyserver in $(shuf -e \
+    		ha.pool.sks-keyservers.net \
+    		hkp://p80.pool.sks-keyservers.net:80 \
+    		keyserver.ubuntu.com \
+    		hkp://keyserver.ubuntu.com:80 \
+    		pgp.mit.edu) ; do \
+    	gpg --keyserver $keyserver --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || true ; \
+    done && \
     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
     rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc && \
     chmod +x /usr/local/bin/gosu && \
@@ -36,7 +43,14 @@ RUN set -x \
   && curl -L -o nomad_${NOMAD_VERSION}_SHA256SUMS      https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS \
   && curl -L -o nomad_${NOMAD_VERSION}_SHA256SUMS.sig  https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
   && export GNUPGHOME="$(mktemp -d)" \
-  && gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C \
+  && for keyserver in $(shuf -e \
+    		ha.pool.sks-keyservers.net \
+    		hkp://p80.pool.sks-keyservers.net:80 \
+    		keyserver.ubuntu.com \
+    		hkp://keyserver.ubuntu.com:80 \
+    		pgp.mit.edu) ; do \
+    	gpg --keyserver $keyserver --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && break || true ; \
+  done \
   && gpg --batch --verify nomad_${NOMAD_VERSION}_SHA256SUMS.sig nomad_${NOMAD_VERSION}_SHA256SUMS \
   && grep nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS | sha256sum -c \
   && unzip -d /bin nomad_${NOMAD_VERSION}_linux_amd64.zip \


### PR DESCRIPTION
Workaround for nomad version 0.8.6 from [Here] (https://github.com/docker-library/mysql/pull/429/files)